### PR TITLE
Add weather data collection example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # wood_1
 우드용 리파지토리
+
+## Weather Agent
+
+`weather_agent.py`는 일본 기상청(JMA)과 OpenWeatherMap에서 도쿄의 날씨 정보를 수집하는 간단한 예제 스크립트입니다.
+
+### 사용법
+
+1. OpenWeatherMap API 키를 `OPENWEATHER_API_KEY` 환경 변수로 설정합니다.
+2. 스크립트를 실행하면 JMA 예보 데이터와 OpenWeatherMap 현재 날씨 정보가 출력됩니다.
+
+```bash
+pip install requests  # 의존 패키지 설치
+export OPENWEATHER_API_KEY=YOUR_API_KEY
+python weather_agent.py
+```

--- a/weather_agent.py
+++ b/weather_agent.py
@@ -1,0 +1,71 @@
+import os
+import requests
+from typing import Dict, Any
+
+
+def fetch_jma_forecast(area_code: str = "130000") -> Dict[str, Any]:
+    """Fetch forecast data from Japan Meteorological Agency.
+
+    Parameters
+    ----------
+    area_code: str
+        The JMA area code. Defaults to Tokyo (130000).
+
+    Returns
+    -------
+    dict
+        Parsed JSON response from JMA.
+    """
+    url = f"https://www.jma.go.jp/bosai/forecast/data/forecast/{area_code}.json"
+    response = requests.get(url, timeout=10)
+    response.raise_for_status()
+    return response.json()
+
+
+def fetch_openweather(city: str = "Tokyo", country: str = "JP") -> Dict[str, Any]:
+    """Fetch current weather from OpenWeatherMap.
+
+    Requires the OPENWEATHER_API_KEY environment variable to be set.
+
+    Parameters
+    ----------
+    city: str
+        City name. Defaults to Tokyo.
+    country: str
+        Country code. Defaults to JP.
+
+    Returns
+    -------
+    dict
+        Parsed JSON response from OpenWeatherMap.
+    """
+    api_key = os.environ.get("OPENWEATHER_API_KEY")
+    if not api_key:
+        raise RuntimeError("OPENWEATHER_API_KEY environment variable not set")
+
+    url = (
+        "https://api.openweathermap.org/data/2.5/weather"
+        f"?q={city},{country}&units=metric&appid={api_key}"
+    )
+    response = requests.get(url, timeout=10)
+    response.raise_for_status()
+    return response.json()
+
+
+def main():
+    jma_data = fetch_jma_forecast()
+    ow_data = fetch_openweather()
+
+    print("JMA forecast (Tokyo):")
+    print(jma_data[0]["timeSeries"][0]["areas"][0])
+
+    print("\nOpenWeatherMap current weather (Tokyo):")
+    print({
+        "description": ow_data["weather"][0]["description"],
+        "temperature": ow_data["main"]["temp"],
+        "humidity": ow_data["main"]["humidity"],
+    })
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `weather_agent.py` to fetch data from JMA and OpenWeatherMap
- document how to use the script in README

## Testing
- `python3 - <<'EOF'
from weather_agent import fetch_jma_forecast
print(len(fetch_jma_forecast()))
EOF
`

------
https://chatgpt.com/codex/tasks/task_e_6889a2234734832690b1b27c6e004be4